### PR TITLE
unflag possible false flags during flood fill

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -172,6 +172,7 @@ class Board:
             visited.add(key)
 
             if not cur.revealed:
+                cur.flagged = False  # unflag if falsely flagged
                 cur.reveal()
 
             if cur.is_mine or cur.num_of_neighbor_mines != 0:


### PR DESCRIPTION
Minor bug fix (which I only encountered because I was being bad at minesweeper...). Now, if you would flag a cell without mine or neighbour mines it will get unflagged during flood fill.