### PR TITLE
unflag possible false flags during flood fill

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -172,6 +172,7 @@ class Board:
             visited.add(key)
 
             if not cur.revealed:
+                cur.flagged = False  # unflag if flagged incorrectly
                 cur.reveal()
 
             if cur.is_mine or cur.num_of_neighbor_mines != 0:


### PR DESCRIPTION
Fixed a minor bug (I discovered while being bad at minesweeper...). Now, if a cell without mine and neighbouring mines got flagged incorrectly, it will be unflagged during flood fill.